### PR TITLE
Remove exception raising when no new tx are found

### DIFF
--- a/etherscan_py/etherscan_py.py
+++ b/etherscan_py/etherscan_py.py
@@ -81,7 +81,7 @@ class Client:
                 if res['status'] == '1':
                     return res['result']
                 else:
-                    raise Exception("Invalid Etherscan request")
+                    return res['result']
         else:
             raise Exception("Invalid HTTP request")
 


### PR DESCRIPTION
Instead of raising an Exception, just return the result as your script seems to be able to handle situations where no transactions are found. 